### PR TITLE
replaced respec ref. to respec-w3c

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset='utf-8'>
     <title>TTML2 Karaoke Extension</title>
     <script
-     src='https://www.w3.org/Tools/respec/respec-w3c-common'
+     src='https://www.w3.org/Tools/respec/respec-w3c'
      class='remove'></script>
     <script class='remove'>
       var respecConfig = {
@@ -17,8 +17,7 @@
         }],
         github: "https://github.com/w3c/ttml-karaoke/",
         shortName: "ttml-karaoke",
-        wg: "Timed Text Working Group",
-        wgURI: "http://www.w3.org/AudioVideo/TT/",
+        group: "wg/timed-text",
         wgPublicList: "public-tt",
         subjectPrefix: "[karaoke]",
         license: "w3c"


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/himorin/tt-module-karaoke/pull/13.html" title="Last updated on Feb 5, 2021, 9:18 AM UTC (dcd3dda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/tt-module-karaoke/13/ab9c688...himorin:dcd3dda.html" title="Last updated on Feb 5, 2021, 9:18 AM UTC (dcd3dda)">Diff</a>